### PR TITLE
fix: import less files in antd lib folder instead of es folder

### DIFF
--- a/src/form/style/index.less
+++ b/src/form/style/index.less
@@ -1,8 +1,8 @@
-@import 'antd/es/style/themes/index';
-@import 'antd/es/style/mixins/index';
-@import 'antd/es/input/style/mixin';
-@import 'antd/es/button/style/mixin';
-@import 'antd/es/grid/style/mixin';
+@import 'antd/lib/style/themes/index';
+@import 'antd/lib/style/mixins/index';
+@import 'antd/lib/input/style/mixin';
+@import 'antd/lib/button/style/mixin';
+@import 'antd/lib/grid/style/mixin';
 @import './mixin';
 
 @form-prefix-cls: ~'@{ant-prefix}-legacy-form';

--- a/src/form/style/mixin.less
+++ b/src/form/style/mixin.less
@@ -1,4 +1,4 @@
-@import 'antd/es/input/style/mixin';
+@import 'antd/lib/input/style/mixin';
 
 .form-control-validation(@text-color: @input-color; @border-color: @input-border-color; @background-color: @input-bg) {
   .@{form-prefix-cls}-explain,

--- a/src/mention/style/index.less
+++ b/src/mention/style/index.less
@@ -1,6 +1,6 @@
-@import 'antd/es/style/themes/index';
-@import 'antd/es/style/mixins/index';
-@import 'antd/es/input/style/mixin';
+@import 'antd/lib/style/themes/index';
+@import 'antd/lib/style/mixins/index';
+@import 'antd/lib/input/style/mixin';
 
 @mention-prefix-cls: ~'@{ant-prefix}-mention';
 


### PR DESCRIPTION
According to [Customize in less file](https://ant.design/docs/react/customize-theme#Customize-in-less-file), I imported `~antd/dist/antd.less` into my less file. And I imported `~@ant-design/compatible/assets/index.less`, when I was migrating to v4. Then when I was trying to build my project, the memory used by nodejs process was increasing endless. I noticed that the less files used in `~antd/dist/antd.less` is from the lib folder, and the less files used in `~@ant-design/compatible/assets/index.less` is from the es folder. So I used the less files in lib folder instead and the problem fixed. I compared both files built from the es folder and built from the lib folder, they was exactly the same.