### PR TITLE
refactor: support external antd

### DIFF
--- a/src/form/Form.tsx
+++ b/src/form/Form.tsx
@@ -3,7 +3,8 @@ import classNames from 'classnames';
 import createDOMForm from 'rc-form/lib/createDOMForm';
 import createFormField from 'rc-form/lib/createFormField';
 import omit from 'omit.js';
-import { ConfigConsumer, ConfigConsumerProps } from 'antd/lib/config-provider';
+import { ConfigProvider } from 'antd';
+import { ConfigConsumerProps } from 'antd/lib/config-provider';
 import { ColProps } from 'antd/lib/grid/col';
 import { tuple } from '../_util/types';
 import warning from '../_util/warning';
@@ -319,7 +320,9 @@ export default class Form extends React.Component<FormProps, any> {
           colon,
         }}
       >
-        <ConfigConsumer>{this.renderForm}</ConfigConsumer>
+        <ConfigProvider.ConfigContext.Consumer>
+          {this.renderForm}
+        </ConfigProvider.ConfigContext.Consumer>
       </FormContext.Provider>
     );
   }

--- a/src/form/FormItem.tsx
+++ b/src/form/FormItem.tsx
@@ -3,9 +3,9 @@ import * as ReactDOM from 'react-dom';
 import classNames from 'classnames';
 import Animate from 'rc-animate';
 import omit from 'omit.js';
-import Row from 'antd/lib/grid/row';
-import Col, { ColProps } from 'antd/lib/grid/col';
-import { ConfigConsumer, ConfigConsumerProps } from 'antd/lib/config-provider';
+import { Row, Col, ConfigProvider } from 'antd';
+import { ColProps } from 'antd/lib/grid/col';
+import { ConfigConsumerProps } from 'antd/lib/config-provider';
 import warning from '../_util/warning';
 import { tuple } from '../_util/types';
 import { FIELD_META_PROP, FIELD_DATA_PROP } from './constants';
@@ -277,9 +277,7 @@ export default class FormItem extends React.Component<FormItemProps, any> {
 
     const icon =
       props.hasFeedback && iconType ? (
-        <span className={`${prefixCls}-item-children-icon`}>
-          {iconType}
-        </span>
+        <span className={`${prefixCls}-item-children-icon`}>{iconType}</span>
       ) : null;
 
     return (
@@ -445,6 +443,10 @@ export default class FormItem extends React.Component<FormItemProps, any> {
   };
 
   render() {
-    return <ConfigConsumer>{this.renderFormItem}</ConfigConsumer>;
+    return (
+      <ConfigProvider.ConfigContext.Consumer>
+        {this.renderFormItem}
+      </ConfigProvider.ConfigContext.Consumer>
+    );
   }
 }

--- a/tests/icon/index.test.tsx
+++ b/tests/icon/index.test.tsx
@@ -8,7 +8,8 @@ import { getThemeFromTypeName, withThemeSuffix } from '../../src/icon/utils';
 
 import { mountTest } from '../utils';
 
-const sleep = (timeout = 0) => new Promise(resolve => setTimeout(resolve, timeout));
+const sleep = (timeout = 0) =>
+  new Promise(resolve => setTimeout(resolve, timeout));
 
 describe('Icon', () => {
   mountTest(Icon);
@@ -93,12 +94,22 @@ describe('Icon', () => {
     icon.simulate('mouseenter');
     expect(onVisibleChange).toHaveBeenCalledWith(true);
     await sleep(0);
-    expect(wrapper.find('.ant-tooltip').at(1).hasClass('ant-tooltip-hidden')).toBe(false);
+    expect(
+      wrapper
+        .find('.ant-tooltip')
+        .at(0)
+        .hasClass('ant-tooltip-hidden'),
+    ).toBe(false);
 
     icon.simulate('mouseleave');
     expect(onVisibleChange).toHaveBeenCalledWith(false);
     await sleep(0);
-    expect(wrapper.find('.ant-tooltip').at(1).hasClass('ant-tooltip-hidden')).toBe(true);
+    expect(
+      wrapper
+        .find('.ant-tooltip')
+        .at(0)
+        .hasClass('ant-tooltip-hidden'),
+    ).toBe(true);
   });
 
   it('should support custom usage of children', () => {


### PR DESCRIPTION
`import { ConfigConsumer, ConfigConsumerProps } from 'antd/lib/config-provider';	` cause 2 problem:
- users can not external antd
- if  someone external antd in his main project, @ant-design/compatible Form ConfigProvider Context will be a different instance, they can not share config 