### PR TITLE
fix: cannot use import statement outside a module

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dayjs": "^1.11.4"
   },
   "peerDependencies": {
-    "antd": "^5.0.0-beta.0",
+    "antd": "^5.0.1",
     "react": ">=16.0.0",
     "react-dom": ">=16.0.0"
   },

--- a/src/comment/style/index.tsx
+++ b/src/comment/style/index.tsx
@@ -3,14 +3,13 @@
 import * as React from 'react';
 import type { CSSInterpolation } from '@ant-design/cssinjs';
 import { useStyleRegister } from '@ant-design/cssinjs';
-import { style, theme as antdTheme, ConfigProvider } from 'antd';
+import { theme as antdTheme, ConfigProvider } from 'antd';
 import type { GlobalToken } from 'antd/es/theme/interface';
+import { resetComponent } from 'antd/lib/style';
 
 interface MergedToken extends GlobalToken {
   componentCls: string;
 }
-
-const { resetComponent } = style;
 
 // ============================== Export ==============================
 const genSharedButtonStyle = (token: MergedToken): CSSInterpolation => {

--- a/src/comment/style/index.tsx
+++ b/src/comment/style/index.tsx
@@ -3,13 +3,14 @@
 import * as React from 'react';
 import type { CSSInterpolation } from '@ant-design/cssinjs';
 import { useStyleRegister } from '@ant-design/cssinjs';
-import { theme as antdTheme, ConfigProvider } from 'antd';
+import { style, theme as antdTheme, ConfigProvider } from 'antd';
 import type { GlobalToken } from 'antd/es/theme/interface';
-import { resetComponent } from 'antd/es/style';
 
 interface MergedToken extends GlobalToken {
   componentCls: string;
 }
+
+const { resetComponent } = style;
 
 // ============================== Export ==============================
 const genSharedButtonStyle = (token: MergedToken): CSSInterpolation => {

--- a/src/theme/convertLegacyToken.ts
+++ b/src/theme/convertLegacyToken.ts
@@ -1,9 +1,7 @@
 // Source:
 // https://github.com/ant-design/ant-design/blob/2c9fbc8f0c714c9de27fc2f54712acb69ac1abd8/components/style/themes/default.less
 import type { MapToken } from 'antd/es/theme/interface';
-import { theme } from 'antd'
-
-const { formatToken } = theme;
+import formatToken from 'antd/es/theme/util/alias';
 
 export default function convertLegacyToken(mapToken: MapToken) {
   const token = formatToken(mapToken as any);

--- a/src/theme/convertLegacyToken.ts
+++ b/src/theme/convertLegacyToken.ts
@@ -1,7 +1,7 @@
 // Source:
 // https://github.com/ant-design/ant-design/blob/2c9fbc8f0c714c9de27fc2f54712acb69ac1abd8/components/style/themes/default.less
 import type { MapToken } from 'antd/es/theme/interface';
-import formatToken from 'antd/es/theme/util/alias';
+import formatToken from 'antd/lib/theme/util/alias';
 
 export default function convertLegacyToken(mapToken: MapToken) {
   const token = formatToken(mapToken as any);

--- a/src/theme/convertLegacyToken.ts
+++ b/src/theme/convertLegacyToken.ts
@@ -1,7 +1,9 @@
 // Source:
 // https://github.com/ant-design/ant-design/blob/2c9fbc8f0c714c9de27fc2f54712acb69ac1abd8/components/style/themes/default.less
 import type { MapToken } from 'antd/es/theme/interface';
-import formatToken from 'antd/es/theme/util/alias';
+import { theme } from 'antd'
+
+const { formatToken } = theme;
 
 export default function convertLegacyToken(mapToken: MapToken) {
   const token = formatToken(mapToken as any);


### PR DESCRIPTION
### Pre-PR

https://github.com/ant-design/ant-design/pull/38832

### Related issue link
- [v4升级至v5中，获得less变量时异常 · Issue #38755 · ant-design/ant-design · GitHub](https://github.com/ant-design/ant-design/issues/38755)
- [antd 4.x 版本升级到 antd 5.x 版本过程中，使用Less Loader未能正确读取 · Discussion #38772 · ant-design/ant-design · GitHub](https://github.com/ant-design/ant-design/discussions/38772)