### PR TITLE
fix: add @ant-design/cssinjs to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@ant-design/cssinjs": "^1.23.0",
     "@ctrl/tinycolor": "^3.6.1",
     "classnames": "^2.2.6",
     "dayjs": "^1.11.4",


### PR DESCRIPTION
Using implicit dependencies causes error with pnpm:

```
Cannot find module '@ant-design/cssinjs'
Require stack:
- /workspace/node_modules/.pnpm/@ant-design+compatible@5.1.4_antd@5.25.1_date-fns@2.30.0_luxon@3.3.0_moment@2.29.4_reac_0e9cd6afde0715f70982a1dc25d7a252/node_modules/@ant-design/compatible/lib/c...
````