### PR TITLE
fix: preserve duplicated legacy form fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "umi-test": "^1.9.7"
   },
   "overrides": {
-    "cheerio": "1.0.0-rc.12"
+    "cheerio": "1.0.0-rc.12",
+    "@types/minimatch": "5.1.2"
   }
 }

--- a/src/form/Form.tsx
+++ b/src/form/Form.tsx
@@ -290,9 +290,34 @@ const FormFC = React.forwardRef((props: FormProps, ref: any) => {
 function create<TOwnProps extends FormComponentProps>(
   options: FormCreateOption<TOwnProps> = {},
 ): FormWrappedProps<TOwnProps> {
+  const mapProps = (options as any).mapProps;
+
   return createDOMForm({
     fieldNameProp: 'id',
     ...options,
+    mapProps(props: any) {
+      const mappedProps = mapProps ? mapProps.call(this, props) : props;
+      const { form } = mappedProps;
+      const fieldNames = new Set<string>();
+      const getFieldDecorator = form.getFieldDecorator;
+
+      return {
+        ...mappedProps,
+        form: {
+          ...form,
+          getFieldDecorator(name: string, fieldOptions?: GetFieldDecoratorOptions) {
+            const fieldName = String(name);
+            const duplicated = fieldNames.has(fieldName);
+            fieldNames.add(fieldName);
+
+            return getFieldDecorator(
+              name,
+              duplicated ? { ...fieldOptions, preserve: true } : fieldOptions,
+            );
+          },
+        },
+      };
+    },
     fieldMetaProp: FIELD_META_PROP,
     fieldDataProp: FIELD_DATA_PROP,
   });

--- a/tests/Form.test.tsx
+++ b/tests/Form.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { ConfigProvider } from 'antd';
+import { ConfigProvider, Input } from 'antd';
 import { Form } from '../src';
-import { render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 
 describe('Form', () => {
   it('no hash', () => {
@@ -15,5 +15,38 @@ describe('Form', () => {
       </ConfigProvider>,
     );
     expect(container).toMatchSnapshot();
+  });
+
+  it('keeps duplicated field value when another field updates', () => {
+    const Demo = Form.create()(({ form }: any) => {
+      const { getFieldDecorator } = form;
+
+      return (
+        <Form>
+          <Form.Item label="Title">
+            {getFieldDecorator('title', {})(<Input placeholder="title" />)}
+          </Form.Item>
+          <Form.Item label="Title">
+            {getFieldDecorator('title', {})(<Input placeholder="title" />)}
+          </Form.Item>
+          <Form.Item label="age">
+            {getFieldDecorator('age', {})(<Input placeholder="age" />)}
+          </Form.Item>
+        </Form>
+      );
+    });
+
+    const { getAllByPlaceholderText, getByPlaceholderText } = render(<Demo />);
+    const titleInputs = getAllByPlaceholderText('title');
+    const ageInput = getByPlaceholderText('age');
+
+    fireEvent.change(titleInputs[0], { target: { value: 'foo' } });
+    expect((titleInputs[0] as HTMLInputElement).value).toBe('foo');
+    expect((titleInputs[1] as HTMLInputElement).value).toBe('foo');
+
+    fireEvent.change(ageInput, { target: { value: '18' } });
+    expect((titleInputs[0] as HTMLInputElement).value).toBe('foo');
+    expect((titleInputs[1] as HTMLInputElement).value).toBe('foo');
+    expect((ageInput as HTMLInputElement).value).toBe('18');
   });
 });

--- a/tests/setupAfterEnv.ts
+++ b/tests/setupAfterEnv.ts
@@ -1,1 +1,17 @@
 import '@testing-library/jest-dom';
+
+if (!window.matchMedia) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: (query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    }),
+  });
+}


### PR DESCRIPTION
判断了如果同一次渲染里出现重复字段名，会自动给重复字段加上 `preserve: true`，避免字段值被清掉。
Fixes ant-design/ant-design#58273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 修复表单重复注册同名字段时的行为：首次注册正常，重复注册时保留已有值且不被后续字段更新覆盖。

* **Tests**
  * 新增/更新用例：验证重复字段在交互修改后值的一致性与保留行为。
  * 测试环境增强：添加 window.matchMedia 的全局 mock 以稳定媒体查询相关测试。

* **Chores**
  * 包配置更新：在 package.json 中锁定 `@types/minimatch` 版本覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->