### PR TITLE
fix: use rc-test npm workflow for CI

### DIFF
--- a/.github/workflows/react-component-ci.yml
+++ b/.github/workflows/react-component-ci.yml
@@ -7,9 +7,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
+          cache: npm
       - run: npm ci
       - run: npm run lint
       - run: npm run lint:tsc
       - run: npm run compile
-      - run: npm test
+      - run: npm test -- --forceExit

--- a/.github/workflows/react-component-ci.yml
+++ b/.github/workflows/react-component-ci.yml
@@ -2,15 +2,5 @@ name: ✅ test
 on: [push, pull_request]
 jobs:
   test:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-      - run: npm ci
-      - run: npm run lint
-      - run: npm run lint:tsc
-      - run: npm run compile
-      - run: npm test -- --forceExit
+    uses: react-component/rc-test/.github/workflows/test-npm.yml@main
+    secrets: inherit

--- a/.github/workflows/react-component-ci.yml
+++ b/.github/workflows/react-component-ci.yml
@@ -2,5 +2,14 @@ name: ✅ test
 on: [push, pull_request]
 jobs:
   test:
-    uses: react-component/rc-test/.github/workflows/test.yml@main
-    secrets: inherit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run lint:tsc
+      - run: npm run compile
+      - run: npm test


### PR DESCRIPTION
Switch from the bun-based rc-test test.yml to test-npm.yml (uses npm, not bun). This project uses father build + umi-test, compatible with test-npm.yml's npm-based steps.